### PR TITLE
Fixed issue with filenames including dots.

### DIFF
--- a/src/ImportIndexer.ts
+++ b/src/ImportIndexer.ts
@@ -204,7 +204,8 @@ export class ImportIndexer
 
         var fsPath = file.fsPath.replace( /[\/\\]/g, "/" );
 
-        var extIdx = fsPath.indexOf( ".", fsPath.lastIndexOf( "/" ) );
+        var lastSlashIdx = fsPath.lastIndexOf("/");
+        var extIdx = lastSlashIdx > 0 ? lastSlashIdx + fsPath.substr(lastSlashIdx).lastIndexOf(".") : fsPath.lastIndexOf(".");
         if( extIdx > 0 )
             fsPath = fsPath.substr( 0, extIdx );
 


### PR DESCRIPTION
The extension has a problem with filenames including dots. 
For example, having a file "a/b/c/todo.component.tsx", the import statement created is:
`import {Todo} from "a/b/c/todo";`
when it should be 
`import {Todo} from "a/b/c/todo.component";`
This is my proposed fix.
