### PR TITLE
Add Vue.js SFC support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 	],
 	"activationEvents": [
 		"onLanguage:typescript",
-		"onLanguage:typescriptreact"
+		"onLanguage:typescriptreact",
+		"onLanguage:vue"
 	],
 	"main": "./out/TypeScriptImporter",
 	"contributes": {
@@ -55,7 +56,7 @@
 			"properties": {
 				"tsimporter.filesToScan": {
 					"type": "array",
-					"default": ["**/*.ts","**/*.tsx"],
+					"default": ["**/*.ts","**/*.tsx","**/*.vue"],
 					"description": "Glob for files to watch and scan, e.g ./src/** ./src/app/**/*.ts. Defaults to [**/*.ts,**/*.tsx]"
 				},
 				"tsimporter.filesToExclude": {

--- a/src/TypeScriptImporter.ts
+++ b/src/TypeScriptImporter.ts
@@ -141,6 +141,9 @@ export class TypeScriptImporter implements vscode.CompletionItemProvider, vscode
         let codeActionFixerReact = vscode.languages.registerCodeActionsProvider('typescriptreact', this)
         let completionItemReact = vscode.languages.registerCompletionItemProvider('typescriptreact', this)
 
+        let codeActionFixerVue = vscode.languages.registerCodeActionsProvider('vue', this)
+        let completionItemVue = vscode.languages.registerCompletionItemProvider('vue', this)
+
         let reindexCommand = vscode.commands.registerCommand( 'tsimporter.reindex', ( ) => {
             
             this.loadConfig();
@@ -254,7 +257,7 @@ export class TypeScriptImporter implements vscode.CompletionItemProvider, vscode
         else
             this.statusBar.show();
 
-        this.context.subscriptions.push( codeActionFixer, completionItem, codeActionFixerReact, completionItemReact, importCommand, dumpSymbolsCommand, this.statusBar );
+        this.context.subscriptions.push( codeActionFixer, completionItem, codeActionFixerReact, completionItemReact, codeActionFixerVue, completionItemVue, importCommand, dumpSymbolsCommand, this.statusBar );
 
         vscode.commands.executeCommand('tsimporter.reindex', { showOutput: true });
     }


### PR DESCRIPTION
Support Vue.js single file components:
- It scans .vue files that typically contain a default export inside a <script> tag.
- It allows completion and importing from a .vue file.

The import feature is not 100% full-proof here because if no import line exists already then the import is inserted at the top of the file rather than under the <script> tag. But it's not a major issue and could be improved later.